### PR TITLE
Enforce resident key for passkey registration

### DIFF
--- a/PasskeyDemo/Services/WebAuthentication.cs
+++ b/PasskeyDemo/Services/WebAuthentication.cs
@@ -23,7 +23,11 @@ public class WebAuthentication : IWebAuthentication
         var options = _fido2.RequestNewCredential(
             user,
             new List<PublicKeyCredentialDescriptor>(),
-            new AuthenticatorSelection(),
+            new AuthenticatorSelection
+            {
+                RequireResidentKey = true,
+                UserVerification = UserVerificationRequirement.Required
+            },
             AttestationConveyancePreference.None,
             new AuthenticationExtensionsClientInputs());
             


### PR DESCRIPTION
## Summary
- require resident key and user verification when requesting new credentials

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68be35d02cec83248c72808f39f4a14e