### PR TITLE
Handle null user handle in assertion

### DIFF
--- a/PasskeyDemo/Controllers/AuthenticationController.cs
+++ b/PasskeyDemo/Controllers/AuthenticationController.cs
@@ -133,7 +133,7 @@ public class AuthenticationController : ControllerBase
     public async Task<IApiResponse<LoginResponseDto>> MakeAssertion([FromBody] MakeAssertionDto assertionDto)
     {
         var userHandle = assertionDto.UserHandle;
-        if (userHandle.Length <= 0)
+        if (userHandle == null || userHandle.Length == 0)
         {
             var userByCredential = await _userCredential.GetUserByCredentialId(assertionDto.Id);
             if (userByCredential is null) return new GenericApiResponse<LoginResponseDto>(null, "Unable to find user");

--- a/PasskeyDemo/Models/DTO/MakeAssertionDto.cs
+++ b/PasskeyDemo/Models/DTO/MakeAssertionDto.cs
@@ -12,7 +12,7 @@ public class MakeAssertionDto : PublicKeyCredentialDto
     public byte[] Signature { get; init; }
     
     [JsonConverter(typeof(Base64UrlConverter))]
-    public byte[] UserHandle { get; init; }
+    public byte[]? UserHandle { get; init; }
     
     public AssertionOptions AssertionOptions { get; init; }
 }


### PR DESCRIPTION
## Summary
- Allow UserHandle in MakeAssertionDto to be nullable
- Retrieve user handle by credential ID when not provided

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68be35d0c9c4832480dea54d82bfa1e7