### PR TITLE
Handle null userHandle in login

### DIFF
--- a/PasskeyDemo/ClientApp/src/app/Services/convert.service.ts
+++ b/PasskeyDemo/ClientApp/src/app/Services/convert.service.ts
@@ -14,6 +14,9 @@ export class ConvertService {
   constructor() { }
 
   CoerceToBase64Url(thing: any): string {
+    if (thing === null || thing === undefined) {
+      return "";
+    }
     // Array or ArrayBuffer to Uint8Array
     if (Array.isArray(thing)) {
       thing = Uint8Array.from(thing);

--- a/PasskeyDemo/ClientApp/src/app/login/login.component.ts
+++ b/PasskeyDemo/ClientApp/src/app/login/login.component.ts
@@ -72,7 +72,9 @@ export class LoginComponent implements OnInit {
     let clientDataJson = this.convertService.CoerceToBase64Url(credentialResponse.clientDataJSON);
     let rawId = this.convertService.CoerceToBase64Url(assertedCredential.rawId);
     let signature = this.convertService.CoerceToBase64Url(credentialResponse.signature);
-    let userHandle = this.convertService.CoerceToBase64Url(credentialResponse.userHandle);
+    let userHandle = credentialResponse.userHandle == null
+      ? ""
+      : this.convertService.CoerceToBase64Url(credentialResponse.userHandle);
 
     let requestBody = {
       id: id,


### PR DESCRIPTION
## Summary
- handle null WebAuthn userHandle in login component
- allow ConvertService.CoerceToBase64Url to gracefully handle null input

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be35d1a3c883248dd7d34422e1f578